### PR TITLE
Fix link formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ CSS-Mint [![npm version](https://badge.fury.io/js/css-mint.svg)](https://badge.f
 > Add some "Mint" to your web pages
 
 <br/>
+
 [http://arunmichaeldsouza.github.io/CSS-Mint/](http://arunmichaeldsouza.github.io/CSS-Mint/)
 
 CSS Mint is an Open Source UI Kit built to cut down front end development time and ease up layout and structuring of your Web Application. Built on top of Normalize.css, it handles cross browser inconsistencies and aims at getting you started with your web project. 


### PR DESCRIPTION
A link in the readme is not formatted well because it's just after a <br/> tag.

Adding an empty line before fixes its.

![screenshot](https://user-images.githubusercontent.com/17952318/34321678-75688646-e815-11e7-8164-865558eacb05.png)
